### PR TITLE
Add mergify file.

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,16 @@
+---
+# See status: 
+# https://doc.mergify.io/configuration.html
+# https://doc.mergify.io/examples.html
+pull_request_rules:
+  - name: Merge PRs from dependabot automatically when it's okay.
+    conditions:
+      - "author=dependabot[bot]"
+      # https://doc.mergify.io/conditions.html#validating-all-status-check
+      - "status-success=ansible-ci (ubuntu1804-ansible28)"
+      - "status-success=ansible-ci (ubuntu1804-ansible29)"
+      - "status-success=ansible-ci (ubuntu2004-ansible28)"
+      - "status-success=ansible-ci (ubuntu2004-ansible29)"
+    actions:
+      merge:
+        method: merge


### PR DESCRIPTION
さっきのMTGで言ってた[mergefy.io](https://mergify.io/)の設定ファイルです。

dashboradにあるシミュレータを使うとマージが走るかどうか確認できる：

https://dashboard.mergify.io/installation/10997269/simulator?repositoryName=ansible-roles_avif&pullRequestNumber=4

<img width="1379" alt="スクリーンショット 2020-08-18 16 10 18" src="https://user-images.githubusercontent.com/51456946/90481803-53b0c500-e16d-11ea-8649-9fe13de60f73.png">

```
      - "status-success=ansible-ci (ubuntu1804-ansible28)"
      - "status-success=ansible-ci (ubuntu1804-ansible29)"
      - "status-success=ansible-ci (ubuntu2004-ansible28)"
      - "status-success=ansible-ci (ubuntu2004-ansible29)"
```
の部分はちょっとお悩みポイントなんだけど、公式のドキュメントを見たら「悪いこと言わんから全部列挙しとけ」って書いてあった

https://doc.mergify.io/conditions.html#validating-all-status-check

```
      - "status-success~=ansible-ci"
      - "#status-success=5"
```

とやっても同じ条件になるけど、github actionsのworkflowの構成が変わると数字を書き換えないといけないのは同じ。
